### PR TITLE
Updates on MEP-11 regarding whitelist for auditing.

### DIFF
--- a/docs/src/development/proposals/MEP11/README.md
+++ b/docs/src/development/proposals/MEP11/README.md
@@ -19,19 +19,16 @@ To avoid data manipulation the S3 compatible storage will be configured to be re
 To reduce the amount of unnecessary logs we want to introduce a whitelist of resources and operations on those that should be logged.
 Other requests will be passed directly to the next middleware or web service without any further processing.
 
-As we are only interested in mutating endpoints, we ignore all GET requests.
-The whitelist includes all `POST`, `PUT` and `DELETE` endpoints of the following services:
+As we are only interested in mutating endpoints, we ignore all `GET` requests.
+The whitelist includes all `POST`, `PUT`, `PATCH` and `DELETE` endpoints the HTTP middleware except for the following (non-manipulating) route suffixes:
 
-- Machines `v1/machine`, except:
-  - `POST v1/machine/find`
-  - `POST v1/machine/ipmi/find`
-- Networks `v1/network`, except:
-  - `POST v1/network/find`
-- IPs `v1/ip`, except:
-  - `POST v1/ip/find`
-- GRPC Services and methods, that can create machines
-  - `api.v1.BootService` method `Register`
-  - `api.v1.EventService` method `Send`
+  - `/find`
+  - `/notify`
+  - `/try` and `/match`
+  - `/capacity`
+  - `/from-hardware`
+
+Regarding GRPC audit trails, they are not so interesting because only internal clients are using this API. However, we can log the trails of the `Boot` service, which can be interesting to revise the machine lifecycle.
 
 ## Chunking in Meilisearch
 

--- a/docs/src/development/proposals/MEP11/README.md
+++ b/docs/src/development/proposals/MEP11/README.md
@@ -20,7 +20,7 @@ To reduce the amount of unnecessary logs we want to introduce a whitelist of res
 Other requests will be passed directly to the next middleware or web service without any further processing.
 
 As we are only interested in mutating endpoints, we ignore all `GET` requests.
-The whitelist includes all `POST`, `PUT`, `PATCH` and `DELETE` endpoints the HTTP middleware except for the following (non-manipulating) route suffixes:
+The whitelist includes all `POST`, `PUT`, `PATCH` and `DELETE` endpoints of the HTTP middleware except for the following (non-manipulating) route suffixes:
 
   - `/find`
   - `/notify`

--- a/docs/src/development/proposals/index.md
+++ b/docs/src/development/proposals/index.md
@@ -13,17 +13,18 @@ Possible states are:
 - `Declined`
 - `In Progress`
 - `Completed`
+- `Aborted`
 
 Once a proposal was accepted, an issue should be raised and the implementation should be done in a separate PR.
 
 | Name                     | Description                                    |      State      |
 | :----------------------- | :--------------------------------------------- | :-------------: |
 | [MEP-1](MEP1/README.md)  | Distributed Control Plane Deployment           | `In Discussion` |
-| [MEP-2](MEP2/README.md)  | Two Factor Authentication                      |  `In Progress`  |
+| [MEP-2](MEP2/README.md)  | Two Factor Authentication                      |    `Aborted`    |
 | [MEP-3](MEP3/README.md)  | Machine Re-Installation to preserve local data |   `Completed`   |
 | [MEP-4](MEP4/README.md)  | Multi-tenancy for the metal-api                |   `Accepted`    |
 | [MEP-5](MEP5/README.md)  | Shared Networks                                |   `Completed`   |
 | [MEP-6](MEP6/README.md)  | DMZ Networks                                   |   `Completed`   |
 | [MEP-8](MEP8/README.md)  | Configurable Filesystemlayout                  |   `Completed`   |
-| [MEP-9](MEP9/README.md)  | No Open Ports To the Data Center               | `In Discussion` |
-| [MEP-11](MEP9/README.md) | Auditing of metal-stack resources              | `In Discussion` |
+| [MEP-9](MEP9/README.md)  | No Open Ports To the Data Center               |  `In Progress`  |
+| [MEP-11](MEP9/README.md) | Auditing of metal-stack resources              |  `In Progress`  |


### PR DESCRIPTION
I would like to create another discussion on the whitelist as I find that the audit trails are extremely valuable to have.

The original MEP only audits three resources, which does not seem reasonable to me. It's really nice to also catch events like somebody altering base entities like editing partitions, replacing switches and so on.

Therefore, I want to propose a blacklist for some routes but in general audit all manipulating endpoints of the api. The amount of data produced should still be pretty identical with this approach (in production setup of FITS < 1000 entries a day).