### PR TITLE
Add metalctl section to MEP14

### DIFF
--- a/docs/src/development/proposals/MEP14/README.md
+++ b/docs/src/development/proposals/MEP14/README.md
@@ -9,6 +9,7 @@ So far, the following components have been identified as requiring changes:
 - metal-images
 
 More components are likely to be added to the list during processing.
+For DNS and NTP servers it should be possible to provide default values within a partition. They can either be inherited from machines and firewalls or overwritten with own ones.
 
 ## pixiecore
 
@@ -21,5 +22,9 @@ If using a self-deployed NTP server, also the metal-hammer need to be configured
 ## metal-images
 
 Configurations for the `metal-images` are different for machines and firewalls.
+
+## metalctl
+
+In order to pass DNS and NTP servers to partitions and machines while creating them, the flags `dnsservers` and `ntpservers` need to be added.
 
 The implementation of this MEP will make metal-stack possible to create and maintain machines without requiring an internet connection.


### PR DESCRIPTION
## Description

Adds additional information to the MEP14 regarding additional flags for `metalctl`

References: https://github.com/metal-stack/metal-api/pull/571
