### PR TITLE
Information on planning meetings.

### DIFF
--- a/docs/src/developers/planning-meetings.md
+++ b/docs/src/developers/planning-meetings.md
@@ -1,8 +1,12 @@
 # Planning Meetings
 
-We are currently planning to setup and maintain a public board for planning development tasks in metal-stack on GitHub [here](https://github.com/orgs/metal-stack/projects/34).
+Please find our development planning board [on GitHub](https://github.com/orgs/metal-stack/projects/34).
 
-We want to introduce public planning meetings soon, please watch out for updates on this page.
+Public planning meetings are held **biweekly** on **odd calendar weeks** from **14:00 to 14:30** on Microsoft Teams. The purpose is to provide an overview of our current projects and priorities, as well as to discuss new topics and issues within the group.
+
+You can use [this link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTVmNWFkYjYtMzVmYi00ZTMxLTk5ZTUtMGFjYjU2OTk0MjQz%40thread.v2/0?context=%7b%22Tid%22%3a%22f9d9b921-8f78-466d-95fd-4495e73d8d65%22%2c%22Oid%22%3a%228ac2a791-e637-4a90-8505-0a1ee175ebfc%22%7d) to join. If you want to get an invitation to the event, please drop us a line on our Slack channel.
+
+Planning meetings are currently not recorded. The meetings are held either in English or German depending on the attendees.
 
 !!! info
 

--- a/docs/src/developers/planning-meetings.md
+++ b/docs/src/developers/planning-meetings.md
@@ -1,8 +1,8 @@
 # Planning Meetings
 
-Please find our development planning board [on GitHub](https://github.com/orgs/metal-stack/projects/34).
-
 Public planning meetings are held **biweekly** on **odd calendar weeks** from **14:00 to 14:30** on Microsoft Teams. The purpose is to provide an overview of our current projects and priorities, as well as to discuss new topics and issues within the group.
+
+Our [development planning board](https://github.com/orgs/metal-stack/projects/34) can be found on GitHub.
 
 You can use [this link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_ZTVmNWFkYjYtMzVmYi00ZTMxLTk5ZTUtMGFjYjU2OTk0MjQz%40thread.v2/0?context=%7b%22Tid%22%3a%22f9d9b921-8f78-466d-95fd-4495e73d8d65%22%2c%22Oid%22%3a%228ac2a791-e637-4a90-8505-0a1ee175ebfc%22%7d) to join. If you want to get an invitation to the event, please drop us a line on our Slack channel.
 


### PR DESCRIPTION
## Description

Replaced #270.

While transitioning to GitHub projects for planning, I thought we might want to make our planning meetings public. Perhaps some people would be interested in joining, which would increase development transparency.

This would require us to have these meetings consistently though. If someone is missing, we should still do them (there must be more people than Stefan and me who can do this).

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
