### PR TITLE
Cumulus is not in release flow anymore.

### DIFF
--- a/docs/src/developers/release-flow.md
+++ b/docs/src/developers/release-flow.md
@@ -18,7 +18,7 @@ A release is created in the following way:
 
 - Individual repository maintainers within the metal-stack GitHub Organization can publish a release of their component.
 - This release is automatically pushed to the `develop` branch of the release repository by the metal-robot.
-- A push triggers a virtual release integration test using the mini-lab environment. This setup launches metal-stack with the `sonic`, `cumulus`, and `gardener` flavors to validate the different Ansible roles and execute basic operations across the metal-stack layer.
+- A push triggers a virtual release integration test using the mini-lab environment. This setup launches metal-stack with the `sonic` and `gardener` flavors to validate the different Ansible roles and execute basic operations across the metal-stack layer.
 - To contribute components that are not directly part of the release vector, a pull request must be made against the `develop` branch of the release repository. Release maintainers may push directly to the `develop` branch.
 - The release maintainers can `/freeze` the `develop` branch, effectively stopping the metal-robot from pushing component releases to this branch.
 - The `develop` branch is tagged by a release maintainer with a `-rc.x` suffix to create a __release candidate__.


### PR DESCRIPTION
## Description

Was not possible to maintain this anymore. Support for people that still use Cumulus is only verified in integration tests now.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
