### PR TITLE
Fix typo in the hardware network cards section

### DIFF
--- a/docs/src/operators/hardware.md
+++ b/docs/src/operators/hardware.md
@@ -37,12 +37,12 @@ Other GPU models might work but were not reported to us. For a detailed descript
 
 The following network cards are officially supported and verified by the metal-stack project for usage in servers:
 
-| Vendor   | Series     | Model                       | Status |
-|----------|------------|-----------------------------|:-------|
-| Intel    | XXV710     | DA2 DualPort 2x25G SFP28    | stable |
-| Intel    | E810       | DA2 DualPort 2x25G SFP28    | stable |
-| Intel    | E810       | CQDA2 DualPort 2x100G SFP28 | stable |
-| Mellanox | ConnectX-5 | MCX512A-ACAT 2x25G SFP28    | stable |
+| Vendor   | Series     | Model                        | Status |
+|----------|------------|------------------------------|:-------|
+| Intel    | XXV710     | DA2 DualPort 2x25G SFP28     | stable |
+| Intel    | E810       | DA2 DualPort 2x25G SFP28     | stable |
+| Intel    | E810       | CQDA2 DualPort 2x100G QSFP28 | stable |
+| Mellanox | ConnectX-5 | MCX512A-ACAT 2x25G SFP28     | stable |
 
 ## Switches
 


### PR DESCRIPTION
Small fix, afaik the Intel E810-CQDA2 has QSFP28 connectors.
